### PR TITLE
fix: search widget replacement input cut off

### DIFF
--- a/src/css/editor_chrome.css
+++ b/src/css/editor_chrome.css
@@ -1348,6 +1348,10 @@ canvas.decorationsOverviewRuler {
     }
 }
 
+.replace-input {
+    max-width: calc(100% - 60px) !important;
+}
+
 :root {
     --flyout-bg: rgba(252, 252, 252, 0.5);
     --menu-bg: rgba(252, 252, 252, 0.5);


### PR DESCRIPTION
Before:
![image](https://github.com/TheOld/vscode-fluent-ui/assets/88338924/d8eed577-23b6-47a5-beeb-7ad4cc80df6a)

After:
![image](https://github.com/TheOld/vscode-fluent-ui/assets/88338924/09958c61-e88b-48d1-b85f-001a1ed3a1f5)
