### PR TITLE
fix background behind page title

### DIFF
--- a/src/css/editor_chrome.css
+++ b/src/css/editor_chrome.css
@@ -555,6 +555,10 @@ html {
     line-height: 22px !important;
 }
 
+.monaco-workbench .part.sidebar>.title{
+    background: none !important;
+}
+
 .sidebar > .content {
     max-width: 100% !important;
     max-height: 96% !important;


### PR DESCRIPTION
![image](https://github.com/TheOld/vscode-fluent-ui/assets/95918679/1be3b01c-3b92-4ffe-8cb9-660a0b5eec38)
Fixes the above image